### PR TITLE
Hotfix Saxon 9.9.1-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>war</packaging>
-	<version>1.2.7-hotfix-saxon_9_9</version>
+	<version>1.2.8</version>
 	<name>Eno-Web-Service</name>
 
 	<properties>
@@ -19,7 +19,7 @@
 
 		<javax.activation.version>1.2.0</javax.activation.version>
 
-		<eno.version>2.2.5-hotfix-saxon_9_9</eno.version>
+		<eno.version>2.2.6</eno.version>
 		<lunatic-model.version>2.1.1</lunatic-model.version>
 		<jaxb.api.version>2.3.0</jaxb.api.version>
 		<springdoc-openapi-ui.version>1.1.48</springdoc-openapi-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>war</packaging>
-	<version>1.2.7</version>
+	<version>1.2.7-hotfix-saxon_9_9</version>
 	<name>Eno-Web-Service</name>
 
 	<properties>
@@ -19,7 +19,7 @@
 
 		<javax.activation.version>1.2.0</javax.activation.version>
 
-		<eno.version>2.2.5</eno.version>
+		<eno.version>2.2.5-hotfix-saxon_9_9</eno.version>
 		<lunatic-model.version>2.1.1</lunatic-model.version>
 		<jaxb.api.version>2.3.0</jaxb.api.version>
 		<springdoc-openapi-ui.version>1.1.48</springdoc-openapi-ui.version>


### PR DESCRIPTION
Minor change of version related to Eno upgrading Saxon version to 9.9.1-8 (which was needed since the big dependencies upgrade (w/ Saxon 10.5) is not yet ready to deploy)