### PR TITLE
Ci/remove lunatic model cloning

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Checkout Eno repo
         uses: actions/checkout@v3
@@ -46,7 +47,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Checkout Eno repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -4,9 +4,9 @@ on: workflow_dispatch
 
 env:
   ENOBRANCH: main
-  LUNATICBRANCH: master
 
 jobs:
+  
   test:
     runs-on: ubuntu-latest
     steps:
@@ -30,23 +30,12 @@ jobs:
         working-directory: ./Eno
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml
 
-      - name: Checkout Lunatic model repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: ${{ env.LUNATICBRANCH }}
-          repository: InseeFr/Lunatic-model
-          path: Lunatic-model
-
-      - name: Build with Maven Lunatic model
-        working-directory: ./Lunatic-model
-        run: mvn install -Djar.finalName="lunatic-model" -B -V --file pom.xml
-
       - name: Test, package and analyze with maven & SonarCloud
         run: mvn verify sonar:sonar -Dsonar.projectKey=InseeFr_Eno-WS -Dsonar.organization=inseefr -Dsonar.host.url=https://sonarcloud.io
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  
   build:
     runs-on: ubuntu-latest
     needs: test
@@ -70,18 +59,6 @@ jobs:
       - name: Build with Maven Eno
         working-directory: ./Eno
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml
-
-      - name: Checkout Lunatic model repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: ${{ env.LUNATICBRANCH }}
-          repository: InseeFr/Lunatic-model
-          path: Lunatic-model
-
-      - name: Build with Maven Lunatic model
-        working-directory: ./Lunatic-model
-        run: mvn install -Djar.finalName="lunatic-model" -B -V --file pom.xml
 
       - name: Build with Maven Eno-WS
         run: mvn clean install -DskipTests=true -B -V --file pom.xml   

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -10,16 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
 
       - name: Checkout Eno repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: ${{ env.ENOBRANCH }}
@@ -40,16 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
 
       - name: Checkout Eno repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: ${{ env.ENOBRANCH }}
@@ -64,7 +64,7 @@ jobs:
         run: mvn clean install -DskipTests=true -B -V --file pom.xml   
 
       - name: Upload war
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war
           path: target/*.war
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download build
         id: download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: war
           path: target/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,16 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
 
       - name: Checkout Eno repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: main
@@ -40,7 +40,7 @@ jobs:
         run: mvn clean package install -DskipTests
 
       - name: Upload war
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war
           path: target/*.war
@@ -50,13 +50,13 @@ jobs:
     needs: test
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       
       - name: Download build
         id: download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: war
           path: target/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Checkout Eno repo
         uses: actions/checkout@v3
@@ -52,7 +53,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
       
       - name: Download build
         id: download

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -30,18 +30,6 @@ jobs:
         working-directory: ./Eno
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml
 
-      - name: Checkout Lunatic model repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: develop
-          repository: InseeFr/Lunatic-model
-          path: Lunatic-model
-
-      - name: Build with Maven Lunatic model
-        working-directory: ./Lunatic-model
-        run: mvn install -Djar.finalName="lunatic-model" -B -V --file pom.xml
-
       - name: Test and analyze with maven & SonarCloud
         run: mvn -e verify sonar:sonar -Dsonar.projectKey=InseeFr_Eno-WS -Dsonar.organization=inseefr -Dsonar.host.url=https://sonarcloud.io
         env:
@@ -56,7 +44,6 @@ jobs:
         with:
           name: war
           path: target/*.war
-
   
   build-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENOBRANCH: main
-      LUNATICBRANCH: master
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,18 +38,6 @@ jobs:
       - name: Build with Maven Eno
         working-directory: ./Eno
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml
-
-      - name: Checkout Lunatic model repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: ${{ env.LUNATICBRANCH }}
-          repository: InseeFr/Lunatic-model
-          path: Lunatic-model
-
-      - name: Build with Maven Lunatic model
-        working-directory: ./Lunatic-model
-        run: mvn install -Djar.finalName="lunatic-model" -B -V --file pom.xml
 
       - name: Test, package and analyze with maven & SonarCloud
         run: mvn -e verify sonar:sonar -Dsonar.projectKey=InseeFr_Eno-WS -Dsonar.organization=inseefr -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Checkout Eno repo
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,16 @@ jobs:
     env:
       ENOBRANCH: main
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
 
       - name: Checkout Eno repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           ref: ${{ env.ENOBRANCH }}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 		<log4j2.version>2.17.0</log4j2.version>
 
-		<lunatic-model.version>2.3.2</lunatic-model.version>
+		<lunatic-model.version>2.3.3</lunatic-model.version>
 
 
 		<jaxb.api.version>2.3.0</jaxb.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,17 @@
 			<name>Spring GA Repository</name>
 			<url>https://repo.spring.io/release</url>
 		</repository>
+		<!-- Maven central snapshot repository (espacially for Lunatic-Model snapshots) -->
+		<repository>
+			<id>oss.sonatype.org-snapshot</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 
 	<!-- spring-boot -->


### PR DESCRIPTION
Lunatic-Model is now published in Maven central 🥳 

Thus, we can remove local installation of Lunatic-Model in workflows

\+ add Maven snapshot repository in pom (in case we want to use snapshots of Lunatic-Model for instance)

Bonus: update actions version