### PR TITLE
feat: pairwise fix, suggester and orbeon 2022

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,8 +7,8 @@ on:
       - labeled
 
 env:
-  ENO_BRANCH: 'dev-pogues2ddi-suggester'
-  LUNATIC_MODEL_BRANCH: 'dev-suggester'
+  ENO_BRANCH: 'next'
+  LUNATIC_MODEL_BRANCH: 'master'
 
 jobs:
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -3,7 +3,7 @@ name: Build docker
 on: workflow_dispatch
 
 env:
-  ENO_BRANCH: main
+  ENO_BRANCH: next
 
 jobs:
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 env:
-  ENO_BRANCH: main
+  ENO_BRANCH: next
 
 jobs:
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<final.war.name>eno-ws</final.war.name>
 
 		<eno.version>2.7.0</eno.version>
-		<lunatic-model.version>2.4.0-SNAPSHOT</lunatic-model.version>
+		<lunatic-model.version>2.5.0</lunatic-model.version>
 		<fop.version>2.9</fop.version>
 
 		<javax.activation.version>1.2.0</javax.activation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<final.war.name>eno-ws</final.war.name>
 
 		<eno.version>2.4.10</eno.version>
-		<lunatic-model.version>2.3.4</lunatic-model.version>
+		<lunatic-model.version>2.4.0-SNAPSHOT</lunatic-model.version>
 		<fop.version>2.9</fop.version>
 
 		<javax.activation.version>1.2.0</javax.activation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<name>Eno-Web-Service</name>
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
-	<version>1.8.4-suggester</version>
+	<version>1.8.5-suggester</version>
 
 	<packaging>war</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<name>Eno-Web-Service</name>
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
-	<version>1.8.4</version>
+	<version>1.8.4-suggester</version>
 
 	<packaging>war</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<name>Eno-Web-Service</name>
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
-	<version>1.8.5-suggester</version>
+	<version>1.8.6-suggester</version>
 
 	<packaging>war</packaging>
 


### PR DESCRIPTION
Upgrade `eno-model` and `lunatic-model` version to include the integrated suggester feature.

(\+ other things)

Functional changes in Eno:

- InseeFr/Eno#759
- InseeFr/Eno#788
- InseeFr/Eno#825

Functional change in Lunatic-Model:

- InseeFr/Lunatic-Model#100
- InseeFr/Lunatic-Model#125
