### PR TITLE
Fix/eno xml wrong zip name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.0</version>
+	<version>2.6.1-SNAPSHOT</version>
 	<name>Eno-Web-Service</name>
 
 	<!-- Spring Boot parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.1-SNAPSHOT</version>
+	<version>2.6.1-SNAPSHOT.1</version>
 	<name>Eno-Web-Service</name>
 
 	<!-- Spring Boot parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.1-SNAPSHOT.2</version>
+	<version>2.6.1</version>
 	<name>Eno-Web-Service</name>
 
 	<!-- Spring Boot parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>eno-ws</artifactId>
 	<packaging>jar</packaging>
-	<version>2.6.1-SNAPSHOT.1</version>
+	<version>2.6.1-SNAPSHOT.2</version>
 	<name>Eno-Web-Service</name>
 
 	<!-- Spring Boot parent -->

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
@@ -148,7 +148,7 @@ public class GenerationCustomController {
 		}
 		log.info("END of Eno Xforms generation processing");
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, true));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromCampagneName(enoParameters));
 	}
 
 	@Operation(
@@ -196,7 +196,7 @@ public class GenerationCustomController {
 			enoOutput = multiModelService.generateQuestionnaire(enoInput, enoParameters, metadataIS, specificTreatmentIS, null);
 		}
 		log.info("END of Eno FO generation processing");
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, true));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromCampagneName(enoParameters));
 
 	}
 

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
@@ -60,7 +60,7 @@ public class GenerationPoguesController {
 		StreamingResponseBody stream = out -> out.write(enoOutput.toByteArray());
 		enoOutput.close();
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, false));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromParameters(enoParameters, false));
 	}
 
 }

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -144,6 +144,8 @@ public class GenerationStandardController {
 				"Received request to transform DDI to a Xforms questionnaire with context '{}' using standard parameters.",
 				context);
 
+		ENOParameters enoParameters = parameterService.getDefaultCustomParameters(context,OutFormat.XFORMS,null);
+
 		ByteArrayOutputStream enoOutput;
 		if (!multiModel)
 			enoOutput = generateQuestionnaireService.generateQuestionnaireFile(
@@ -152,7 +154,7 @@ public class GenerationStandardController {
 			enoOutput = generateQuestionnaireService.generateMultiModelQuestionnaires(
 					context, OutFormat.XFORMS, null, in, metadata, specificTreatment);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameWithoutEnoParameters(OutFormat.XFORMS, multiModel));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, multiModel));
 	}
 
 	@Operation(
@@ -224,10 +226,12 @@ public class GenerationStandardController {
 				"Received request to transform DDI to a fodt specification file with context '{}' using standard parameters.",
 				context);
 
+		ENOParameters enoParameters = parameterService.getDefaultCustomParameters(context,OutFormat.FODT,null);
+
 		ByteArrayOutputStream enoOutput = generateQuestionnaireService.generateQuestionnaireFile(
 				context, OutFormat.FODT, null, in, null, null);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameWithoutEnoParameters(OutFormat.FODT, false));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, false));
 	}
 
 }

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -144,8 +144,6 @@ public class GenerationStandardController {
 				"Received request to transform DDI to a Xforms questionnaire with context '{}' using standard parameters.",
 				context);
 
-		ENOParameters enoParameters = parameterService.getDefaultCustomParameters(context,OutFormat.XFORMS,null);
-
 		ByteArrayOutputStream enoOutput;
 		if (!multiModel)
 			enoOutput = generateQuestionnaireService.generateQuestionnaireFile(
@@ -154,7 +152,7 @@ public class GenerationStandardController {
 			enoOutput = generateQuestionnaireService.generateMultiModelQuestionnaires(
 					context, OutFormat.XFORMS, null, in, metadata, specificTreatment);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, multiModel));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromParameters(OutFormat.XFORMS, multiModel));
 	}
 
 	@Operation(
@@ -208,7 +206,7 @@ public class GenerationStandardController {
 
 
 		log.info("END of Eno FO questionnaire processing");
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput,parameterService.getFileNameFromEnoParameters(enoParameters, multiModel));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput,parameterService.getFileNameFromParameters(enoParameters, multiModel));
 	}
 
 	@Operation(
@@ -226,12 +224,10 @@ public class GenerationStandardController {
 				"Received request to transform DDI to a fodt specification file with context '{}' using standard parameters.",
 				context);
 
-		ENOParameters enoParameters = parameterService.getDefaultCustomParameters(context,OutFormat.FODT,null);
-
 		ByteArrayOutputStream enoOutput = generateQuestionnaireService.generateQuestionnaireFile(
 				context, OutFormat.FODT, null, in, null, null);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, false));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromParameters(OutFormat.FODT, false));
 	}
 
 }

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -152,7 +152,7 @@ public class GenerationStandardController {
 			enoOutput = generateQuestionnaireService.generateMultiModelQuestionnaires(
 					context, OutFormat.XFORMS, null, in, metadata, specificTreatment);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(OutFormat.XFORMS, multiModel));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameWithoutEnoParameters(OutFormat.XFORMS, multiModel));
 	}
 
 	@Operation(
@@ -227,7 +227,7 @@ public class GenerationStandardController {
 		ByteArrayOutputStream enoOutput = generateQuestionnaireService.generateQuestionnaireFile(
 				context, OutFormat.FODT, null, in, null, null);
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(OutFormat.FODT, false));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameWithoutEnoParameters(OutFormat.FODT, false));
 	}
 
 }

--- a/src/main/java/fr/insee/eno/ws/controller/GenerationWithMappingController.java
+++ b/src/main/java/fr/insee/eno/ws/controller/GenerationWithMappingController.java
@@ -81,7 +81,7 @@ public class GenerationWithMappingController {
 			log.info("END of Eno 'in to out' processing");
 		}
 
-		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromEnoParameters(enoParameters, multiModel));
+		return ResponseUtils.generateResponseFromOutputStream(enoOutput, parameterService.getFileNameFromParameters(enoParameters, multiModel));
 	}
 
 }

--- a/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -61,22 +61,30 @@ public class ParameterService {
 		return xmlParameters;
 	}
 
-	public String getFileNameFromEnoParameters(ENOParameters enoParameters, boolean multiModel){
-		if (enoParameters.getParameters().getCampagne() == null || enoParameters.getParameters().getCampagne().isEmpty()) {
-			throw new EnoParametersException("The 'campagne' tag is null or empty.");
+	public String getFileNameFromCampagneName(ENOParameters enoParameters) {
+		if (enoParameters == null || enoParameters.getParameters() == null || enoParameters.getParameters().getCampagne() == null ||
+				enoParameters.getParameters().getCampagne().isEmpty()) {
+				throw new EnoParametersException("The 'campagne' tag is null or empty.");
+			}
+		return enoParameters.getParameters().getCampagne() + ".zip";
+	}
+
+	public String getFileNameFromParameters(ENOParameters enoParameters, boolean multiModel){
+		return getFileNameFromParameters(enoParameters.getPipeline().getOutFormat(), multiModel);
+	}
+
+	public String getFileNameFromParameters (OutFormat outFormat,boolean multiModel){
+		if (multiModel) return "questionnaires.zip";
+		return switch (outFormat) {
+				case FO -> "questionnaire.fo";
+				case FODT -> "questionnaire.fodt";
+				case DDI -> "ddi-questionnaire.xml";
+				case LUNATIC_XML -> "lunatic-questionnaire.xml";
+				case XFORMS -> "questionnaire.xhtml";
+			};
 		}
-		return getFileNameFromParameters(enoParameters.getPipeline().getOutFormat(), multiModel, enoParameters.getParameters().getCampagne());
 	}
 
-	public String getFileNameFromParameters(OutFormat outFormat, boolean multiModel, String campagne){
-		if(multiModel) return campagne + ".zip";
-		return switch (outFormat){
-			case FO -> campagne + ".fo";
-			case FODT -> campagne + ".fodt";
-			case DDI -> "ddi-questionnaire.xml";
-			case LUNATIC_XML -> "lunatic-questionnaire.xml";
-			case XFORMS -> campagne + ".xhtml";
-		};
-	}
 
-}
+
+

--- a/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -77,7 +77,7 @@ public class ParameterService {
 	}
 
 	public String getFileNameWithoutEnoParameters(OutFormat outFormat, boolean multiModel){
-		if(multiModel) return "questionnaire.zip";
+		if(multiModel) return "questionnaires.zip";
 		return switch (outFormat){
 			case FO -> "questionnaire.fo";
 			case FODT -> "questionnaire.fodt";

--- a/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -62,28 +62,17 @@ public class ParameterService {
 	}
 
 	public String getFileNameFromEnoParameters(ENOParameters enoParameters, boolean multiModel){
-		return getFileNameFromEnoParameters(enoParameters.getPipeline().getOutFormat(), multiModel, enoParameters.getParameters().getCampagne());
+		return getFileNameFromParameters(enoParameters.getPipeline().getOutFormat(), multiModel, enoParameters.getParameters().getCampagne());
 	}
 
-	public String getFileNameFromEnoParameters(OutFormat outFormat, boolean multiModel, String campagne){
+	public String getFileNameFromParameters(OutFormat outFormat, boolean multiModel, String campagne){
 		if(multiModel) return campagne + ".zip";
 		return switch (outFormat){
 			case FO -> campagne + ".fo";
-			case FODT -> "questionnaire.fodt";
+			case FODT -> campagne + ".fodt";
 			case DDI -> "ddi-questionnaire.xml";
 			case LUNATIC_XML -> "lunatic-questionnaire.xml";
 			case XFORMS -> campagne + ".xhtml";
-		};
-	}
-
-	public String getFileNameWithoutEnoParameters(OutFormat outFormat, boolean multiModel){
-		if(multiModel) return "questionnaires.zip";
-		return switch (outFormat){
-			case FO -> "questionnaire.fo";
-			case FODT -> "questionnaire.fodt";
-			case DDI -> "ddi-questionnaire.xml";
-			case LUNATIC_XML -> "lunatic-questionnaire.xml";
-			case XFORMS -> "questionnaire.xhtml";
 		};
 	}
 

--- a/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -62,6 +62,9 @@ public class ParameterService {
 	}
 
 	public String getFileNameFromEnoParameters(ENOParameters enoParameters, boolean multiModel){
+		if (enoParameters.getParameters().getCampagne() == null || enoParameters.getParameters().getCampagne().isEmpty()) {
+			throw new EnoParametersException("The 'campagne' tag is null or empty.");
+		}
 		return getFileNameFromParameters(enoParameters.getPipeline().getOutFormat(), multiModel, enoParameters.getParameters().getCampagne());
 	}
 

--- a/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -62,11 +62,22 @@ public class ParameterService {
 	}
 
 	public String getFileNameFromEnoParameters(ENOParameters enoParameters, boolean multiModel){
-		return getFileNameFromEnoParameters(enoParameters.getPipeline().getOutFormat(), multiModel);
+		return getFileNameFromEnoParameters(enoParameters.getPipeline().getOutFormat(), multiModel, enoParameters.getParameters().getCampagne());
 	}
 
-	public String getFileNameFromEnoParameters(OutFormat outFormat, boolean multiModel){
-		if(multiModel) return "questionnaires.zip";
+	public String getFileNameFromEnoParameters(OutFormat outFormat, boolean multiModel, String campagne){
+		if(multiModel) return campagne + ".zip";
+		return switch (outFormat){
+			case FO -> campagne + ".fo";
+			case FODT -> "questionnaire.fodt";
+			case DDI -> "ddi-questionnaire.xml";
+			case LUNATIC_XML -> "lunatic-questionnaire.xml";
+			case XFORMS -> campagne + ".xhtml";
+		};
+	}
+
+	public String getFileNameWithoutEnoParameters(OutFormat outFormat, boolean multiModel){
+		if(multiModel) return "questionnaire.zip";
 		return switch (outFormat){
 			case FO -> "questionnaire.fo";
 			case FODT -> "questionnaire.fodt";
@@ -75,6 +86,5 @@ public class ParameterService {
 			case XFORMS -> "questionnaire.xhtml";
 		};
 	}
-	
 
 }

--- a/src/main/java/fr/insee/eno/ws/service/QuestionnaireGenerateService.java
+++ b/src/main/java/fr/insee/eno/ws/service/QuestionnaireGenerateService.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.zip.ZipOutputStream;
 
 @Service
 @Slf4j
@@ -51,9 +52,9 @@ public class QuestionnaireGenerateService {
 	}
 
 	public ByteArrayOutputStream generateMultiModelQuestionnaires(Context context, OutFormat outFormat, Mode mode,
-												 MultipartFile in,
-												 MultipartFile metadata,
-												 MultipartFile specificTreatment) throws Exception {
+																 MultipartFile in,
+																 MultipartFile metadata,
+																 MultipartFile specificTreatment) throws Exception {
 
 		ENOParameters enoParameters = parameterService.getDefaultCustomParameters(context, outFormat, mode);
 		ByteArrayOutputStream enoOutput;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 #############  Swagger host ############# 
 fr.insee.enows.api.scheme=http
-#fr.insee.enows.api.host=localhost:8080
-fr.insee.enows.api.host=localhost:8082
-
-server.port=8082
+fr.insee.enows.api.host=localhost:8080
 
 # Sort API tags alphabetically in the swagger ui
 springdoc.swagger-ui.tagsSorter=alpha

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 #############  Swagger host ############# 
 fr.insee.enows.api.scheme=http
-fr.insee.enows.api.host=localhost:8080
+#fr.insee.enows.api.host=localhost:8080
+fr.insee.enows.api.host=localhost:8082
+
+server.port=8082
 
 # Sort API tags alphabetically in the swagger ui
 springdoc.swagger-ui.tagsSorter=alpha


### PR DESCRIPTION
- Nommage corrigé pour tous les endpoints (hors Lunatic et Pogues) : obtention du paramètre "campagne" personnalisé ou celui par défaut (custom parameters / standard parameters).

- Exception créée pour gérer les balises manquantes/vides du paramètre "campagne" (il ne doit pas être possible de générer un zip/fichier dans de telles situations).