### PR TITLE
Personnalisation dans les libellés de Description des filtres

### DIFF
--- a/eno-core/src/main/resources/xslt/inputs/ddi/functions.fods
+++ b/eno-core/src/main/resources/xslt/inputs/ddi/functions.fods
@@ -1444,6 +1444,20 @@
     </table:table-row>
     <table:table-row table:style-name="ro1">
      <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>enoddi:get-flowcontrol-label-conditioning-variables</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>language</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>xs:string*</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>Function that returns the list of the variables conditioning the label of a filter</text:p>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="ro1">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enoddi:is-required</text:p>
      </table:table-cell>
      <table:table-cell/>

--- a/eno-core/src/main/resources/xslt/inputs/ddi/source-fixed.xsl
+++ b/eno-core/src/main/resources/xslt/inputs/ddi/source-fixed.xsl
@@ -889,6 +889,22 @@
 
     <xd:doc>
         <xd:desc>
+            <xd:p>Defining getter get-flowcontrol-label-conditioning-variables.</xd:p>
+            <xd:p>Function that returns the list of the variables of the label of a filter.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="d:ThenConstructReference" mode="enoddi:get-flowcontrol-label-conditioning-variables">
+        <xsl:param name="language" tunnel="yes"/>
+        <xsl:variable name="variable-list" as="xs:string *">
+            <xsl:call-template name="enoddi:variables-from-label">
+                <xsl:with-param name="label" select="eno:serialize(enoddi:get-flowcontrol-label(.,$language))"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:sequence select="$variable-list"/>
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
             <xd:p>Defining getter get-computated-maximum-lines-variables.</xd:p>
             <xd:p>Function that returns the list of the variables of the ConditionForContinuation of a dynamic array.</xd:p>
         </xd:desc>

--- a/eno-core/src/main/resources/xslt/inputs/pogues-xml/source-fixed.xsl
+++ b/eno-core/src/main/resources/xslt/inputs/pogues-xml/source-fixed.xsl
@@ -237,7 +237,7 @@
         <xsl:sequence select="//pogues:Variable[@id = $idVariable]"/>
     </xsl:template>
 
-    <xsl:template match="pogues:Expression | pogues:Formula | pogues:Text | pogues:Control/pogues:FailMessage | pogues:Label | pogues:Loop/pogues:Maximum | pogues:Loop/pogues:Minimum | pogues:Loop/pogues:Filter | pogues:OccurrenceLabel | pogues:OccurrenceDescription | pogues:Unit | pogues:FixedLength | pogues:value[../pogues:type='VTL']" mode="enopogues:get-related-variable">
+    <xsl:template match="pogues:Expression | pogues:Formula | pogues:Text | pogues:Control/pogues:FailMessage | pogues:Label | pogues:Loop/pogues:Maximum | pogues:Loop/pogues:Minimum | pogues:Loop/pogues:Filter | pogues:OccurrenceLabel | pogues:OccurrenceDescription | pogues:Unit | pogues:FixedLength | pogues:value[../pogues:type='VTL'] | pogues:Description" mode="enopogues:get-related-variable">
         <xsl:variable name="expressionVariable" select="tokenize(., '\$')"/>
         <xsl:variable name="variables" select="//pogues:Variables"/>
 
@@ -303,7 +303,7 @@
             select="concat($context/parent::pogues:Child/@id, '-secondDimension-fakeCL-1')"/>
     </xsl:function>
 
-    <xsl:template match="pogues:Declaration/pogues:Text | pogues:Control/pogues:FailMessage | pogues:Label | pogues:OccurrenceLabel | pogues:OccurrenceDescription | pogues:Unit[../pogues:IsDynamicUnit='true'] | pogues:FixedLength | pogues:value[../pogues:type='VTL']" mode="id-variable">
+    <xsl:template match="pogues:Declaration/pogues:Text | pogues:Control/pogues:FailMessage | pogues:Label | pogues:OccurrenceLabel | pogues:OccurrenceDescription | pogues:Unit[../pogues:IsDynamicUnit='true'] | pogues:FixedLength | pogues:value[../pogues:type='VTL'] | pogues:Description" mode="id-variable">
         <xsl:variable name="variables" select="enopogues:get-related-variable(.)"/>
         <xsl:choose>
             <xsl:when test="$variables">

--- a/eno-core/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/eno-core/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -834,7 +834,10 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Description</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2"/>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>id-variable</text:p>
+     </table:table-cell>
+     <table:table-cell/>
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">

--- a/eno-core/src/main/resources/xslt/outputs/fo/models.xsl
+++ b/eno-core/src/main/resources/xslt/outputs/fo/models.xsl
@@ -121,7 +121,7 @@
 				<xsl:text>&#xd;#end&#xd;</xsl:text>
 			</xsl:when>
 			<xsl:otherwise>
-				<xsl:variable name="label" select="enofo:get-flowcontrol-label($source-context,$languages[1])"/>
+				<xsl:variable name="label" select="enofo:get-flowcontrol-label($source-context, $languages[1],$loop-navigation)"/>
 				<xsl:if test="$label != ''">
 					<fo:block page-break-inside="avoid" keep-with-previous="always">
 						<xsl:copy-of select="$style-parameters/filter-block/@*"/>

--- a/eno-core/src/main/resources/xslt/transformations/ddi2fo/ddi2fo-fixed.xsl
+++ b/eno-core/src/main/resources/xslt/transformations/ddi2fo/ddi2fo-fixed.xsl
@@ -336,6 +336,19 @@
         <xsl:sequence select="$tempLabel"/>
     </xsl:function>
 
+    <xsl:function name="enofo:get-flowcontrol-label">
+        <xsl:param name="context" as="item()"/>
+        <xsl:param name="language"/>
+        <xsl:param name="loop-navigation" as="node()"/>
+        <xsl:variable name="tempLabel">
+            <xsl:apply-templates select="enoddi:get-flowcontrol-label($context,$language)" mode="enofo:format-label">
+                <xsl:with-param name="label-variables" select="enoddi:get-flowcontrol-label-conditioning-variables($context,$language)" tunnel="yes"/>
+                <xsl:with-param name="loop-navigation" select="$loop-navigation" as="node()" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:sequence select="$tempLabel"/>
+    </xsl:function>    
+
     <xsl:template match="*" mode="enofo:format-label" priority="-1">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*" mode="enofo:format-label"/>

--- a/eno-core/src/main/resources/xslt/transformations/ddi2fo/functions.fods
+++ b/eno-core/src/main/resources/xslt/transformations/ddi2fo/functions.fods
@@ -1209,20 +1209,6 @@
     </table:table-row>
     <table:table-row table:style-name="ro1">
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>enofo:get-flowcontrol-label</text:p>
-     </table:table-cell>
-     <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>language</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
-      <text:p>enoddi:get-flowcontrol-label</text:p>
-     </table:table-cell>
-     <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>Linking output function enofo:get-flowcontrol-label to input function enoddi:get-flowcontrol-label.</text:p>
-     </table:table-cell>
-    </table:table-row>
-    <table:table-row table:style-name="ro1">
-     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enofo:get-maximum</text:p>
      </table:table-cell>
      <table:table-cell/>


### PR DESCRIPTION
- pogues-xml -> ddi : recherche des variables pour remplacer les $ par des ¤
- ddi -> fo : recherche des variables entre ¤ pour leur appliquer les transformations des libellés personnalisés.